### PR TITLE
Corrected the lib loading behavior for non "win32" platforms

### DIFF
--- a/openal/library_loader.py
+++ b/openal/library_loader.py
@@ -36,14 +36,14 @@ class ExternalLibrary:
             _loaded_libraries[name] = lib
             return lib
         else:
-            lib = ExternalLibrary.load_windows(name, paths)
+            lib = ExternalLibrary.load_other(name, paths)
             _loaded_libraries[name] = lib
             return lib
 
     @staticmethod
     def load_other(name, paths = None):
         library = ctypes.util.find_library(name)
-        if library and os.path.isfile(library):
+        if library:
             return ctypes.CDLL(library)
 
         if paths:


### PR DESCRIPTION
I was trying to use the openal wrapper for python on a Arch-Linux system and realized, that the loading behaviour of the external openal lib was not working. Those corrections fixed it on my side and I think they should also be valid for most other non-win32 platforms.