### PR TITLE
Ensure library exists before loading it

### DIFF
--- a/openal/library_loader.py
+++ b/openal/library_loader.py
@@ -49,10 +49,11 @@ class ExternalLibrary:
         for style in _other_styles:
             candidate = style.format(name)
             library = ctypes.util.find_library(candidate)
-            try:
-                return ctypes.CDLL(library)
-            except:
-                pass
+            if library:
+                try:
+                    return ctypes.CDLL(library)
+                except:
+                    pass
 
     @staticmethod
     def load_windows(name, paths = None):


### PR DESCRIPTION
On Linux, due to the lack of check that `library` is not `None`, the OpenAL library would fail to load if "soft_oal" was not installed (as it returns an empty but truthy library, and so doesn't check the other candidates).

This only became an issue for me in the latest version, since the order in which it attempts to load libraries was changed from `("openal", "OpenAL32", "soft_oal")` to `("soft_oal", "OpenAL32", "openal")`.